### PR TITLE
refactor(test): test to check if Infinity doesn't error

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -88,6 +88,14 @@ db.on("end", () => console.log("ℹ️ Database connection ended"));
   // Test 14
   new Test(await db.get("users.0.username")).test("One");
 
+  // Test 15
+  try {
+    await db.set("users.0.points", Infinity);
+    new Test(false).test(false);
+  } catch {
+    new Test(true).test(true);
+  }
+
   console.timeEnd("⏱ Time to test (excludes connection & end)");
 
   await db.drop();


### PR DESCRIPTION
Add a test to check if setting `Infinity` to a field errors. The expected value is that it errors, if it doesn't, the test fails.

This test was missed during the initial release.